### PR TITLE
Fix typo in Exceptions.hpp

### DIFF
--- a/shared-headers/Exceptions.hpp
+++ b/shared-headers/Exceptions.hpp
@@ -87,7 +87,7 @@ Generic_Exception(TODO);
 #ifdef MACRO_COUNTERS_ALL
 #define COUNTERS_BLOCK() if constexpr (true)
 #else
-#define COUNTERS_BLOCK() if constexpr (else)
+#define COUNTERS_BLOCK() if constexpr (false)
 #endif
 // -------------------------------------------------------------------------------------
 template <typename T>


### PR DESCRIPTION
Fix a typo in constexpr so that it can build without `MACRO_COUNTERS_ALL` set.

(Hope it is not a hidden c++ magic that I'm not aware of...)