### PR TITLE
Fixed 2 issues: Memory resource not released and flushing of non-dirty pages

### DIFF
--- a/backend/leanstore/concurrency-recovery/CRMG.cpp
+++ b/backend/leanstore/concurrency-recovery/CRMG.cpp
@@ -95,6 +95,11 @@ void CRManager::registerMeAsSpecialWorker()
 {
    cr::Worker::tls_ptr = new Worker(std::numeric_limits<WORKERID>::max(), workers, workers_count, versions_space, ssd_fd, true);
 }
+
+void CRManager::deleteSpecialWorker()
+{
+   delete cr::Worker::tls_ptr;
+}
 // -------------------------------------------------------------------------------------
 void CRManager::scheduleJobSync(u64 t_i, std::function<void()> job)
 {

--- a/backend/leanstore/concurrency-recovery/CRMG.hpp
+++ b/backend/leanstore/concurrency-recovery/CRMG.hpp
@@ -51,6 +51,7 @@ class CRManager
    ~CRManager();
    // -------------------------------------------------------------------------------------
    void registerMeAsSpecialWorker();
+   void deleteSpecialWorker();
    // -------------------------------------------------------------------------------------
    /**
     * @brief Schedule same job on specific amount of workers.

--- a/backend/leanstore/concurrency-recovery/Worker.cpp
+++ b/backend/leanstore/concurrency-recovery/Worker.cpp
@@ -52,6 +52,8 @@ Worker::Worker(u64 worker_id, Worker** all_workers, u64 workers_count, HistoryTr
 Worker::~Worker()
 {
    delete[] cc.commit_tree.array;
+   std::free(logging.wal_buffer);
+   logging.wal_buffer = nullptr;
 }
 // -------------------------------------------------------------------------------------
 void Worker::startTX(TX_MODE next_tx_type, TX_ISOLATION_LEVEL next_tx_isolation_level, bool read_only)

--- a/backend/leanstore/storage/buffer-manager/BufferFrame.hpp
+++ b/backend/leanstore/storage/buffer-manager/BufferFrame.hpp
@@ -81,7 +81,10 @@ struct BufferFrame {
    // -------------------------------------------------------------------------------------
    bool operator==(const BufferFrame& other) { return this == &other; }
    // -------------------------------------------------------------------------------------
-   inline bool isDirty() const { return page.PLSN != header.last_written_plsn; }
+   inline bool isDirty() const { return 
+      page.PLSN != 0 && // marked as dirty
+      page.PLSN != header.last_written_plsn // and not written
+   ; }
    inline bool isFree() const { return header.state == STATE::FREE; }
    // -------------------------------------------------------------------------------------
    // Pre: bf is exclusively locked

--- a/backend/leanstore/storage/buffer-manager/PageProviderThread.cpp
+++ b/backend/leanstore/storage/buffer-manager/PageProviderThread.cpp
@@ -101,7 +101,7 @@ void BufferManager::pageProviderThread(u64 p_begin, u64 p_end)  // [p_begin, p_e
                });
                COUNTERS_BLOCK()
                {
-                  iterate_children_begin = std::chrono::high_resolution_clock::now();
+                  iterate_children_end = std::chrono::high_resolution_clock::now();
                   PPCounters::myCounters().iterate_children_ms +=
                       (std::chrono::duration_cast<std::chrono::microseconds>(iterate_children_end - iterate_children_begin).count());
                }
@@ -315,8 +315,8 @@ void BufferManager::pageProviderThread(u64 p_begin, u64 p_end)  // [p_begin, p_e
       }
       COUNTERS_BLOCK() { PPCounters::myCounters().pp_thread_rounds++; }
    }
+   cr::CRManager::global->deleteSpecialWorker();
    bg_threads_counter--;
-   //   delete cr::Worker::tls_ptr;
 }
 // -------------------------------------------------------------------------------------
 }  // namespace storage

--- a/frontend/shared/rocksdb.cpp
+++ b/frontend/shared/rocksdb.cpp
@@ -2,4 +2,7 @@
 
 using namespace rocksdb;
 
-rocksdb::DB::~DB() {};
+// Force the compiler to include type information for rocksdb::DB
+void ensureTypeInfo() {
+    const std::type_info& ti = typeid(DB);
+}

--- a/frontend/shared/rocksdb.cpp
+++ b/frontend/shared/rocksdb.cpp
@@ -2,7 +2,4 @@
 
 using namespace rocksdb;
 
-// Force the compiler to include type information for rocksdb::DB
-void ensureTypeInfo() {
-    const std::type_info& ti = typeid(DB);
-}
+rocksdb::DB::~DB() {};


### PR DESCRIPTION
Fixed 2 issues:

- Several resources not released when the executable exits, leading to it not passing [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html).
- `BufferFrame::isDirty()` flushes page with `PLSN == 0`, which are not modified, I believe. With the original code, experiments recovered from existing DB with read-only TXs witness page writes consistently above zero.

The fixed code passes multiple runs of various experiments, including persisting and recovering (& verifying). But I would still appreciate a set of fresh eyes, especially because the changes are cherrypicked from [my branch](https://github.com/alicia-lyu/leanstore.git).