### PR TITLE
Fix #17: Support clang by updating RocksDB

### DIFF
--- a/frontend/shared/rocksdb.cpp
+++ b/frontend/shared/rocksdb.cpp
@@ -2,4 +2,7 @@
 
 using namespace rocksdb;
 
-rocksdb::DB::~DB() {};
+// Force the compiler to include type information for rocksdb::DB
+void ensureTypeInfo() {
+    const std::type_info& ti = typeid(DB);
+}

--- a/libs/rocksdb.cmake
+++ b/libs/rocksdb.cmake
@@ -12,13 +12,13 @@ ExternalProject_Add(
         rocksdb_src
         PREFIX "vendor/rocksdb"
         GIT_REPOSITORY "https://github.com/facebook/rocksdb.git"
-        GIT_TAG abd4b1ff1504ae2a7ed6e60bc9c9797b880c33a5
+        GIT_TAG 5f003e4a22d2e48e37c98d9620241237cd30dd24
         GIT_SHALLOW TRUE
         TIMEOUT 10
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         INSTALL_COMMAND ""
-        BUILD_COMMAND $(MAKE) static_lib
+        BUILD_COMMAND $(MAKE) static_lib USE_RTTI=1
         BUILD_IN_SOURCE TRUE
 )
 


### PR DESCRIPTION
Use the newest release of rocksdb. The project should be able to compile with Clang now. Note that this commit is cherrypicked from [my branch](https://github.com/alicia-lyu/leanstore), which commented out frontend executables not using LeanStore and RocksDB. This may only solve part of the problem.