### PR TITLE
Fix incorrect random numeric generation from randomNumeric function

### DIFF
--- a/frontend/tpc-c/TPCCWorkload.hpp
+++ b/frontend/tpc-c/TPCCWorkload.hpp
@@ -91,7 +91,7 @@ class TPCCWorkload
    Numeric randomNumeric(Numeric min, Numeric max)
    {
       double range = (max - min);
-      double div = RAND_MAX / range;
+      double div = UINT64_MAX / range;
       return min + (leanstore::utils::RandomGenerator::getRandU64() / div);
    }
 


### PR DESCRIPTION
Replace RAND_MAX with UINT64_MAX in randomNumeric function which affected all numeric values generated by this function in TPC-C workload.

All calls to randomNumeric() were generating incorrect values due to using RAND_MAX (2^31-1) instead of UINT64_MAX (2^64-1).