### PR TITLE
fix profiling when print_tx_console is off

### DIFF
--- a/backend/leanstore/LeanStore.cpp
+++ b/backend/leanstore/LeanStore.cpp
@@ -227,10 +227,10 @@ void LeanStore::startProfilingThread()
                print_table(table, [](u64 line_n) { return line_n == 4; });
             }
             // -------------------------------------------------------------------------------------
-            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-            seconds += 1;
             std::locale::global(std::locale::classic());
          }
+         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+         seconds += 1;
       }
       bg_threads_counter--;
    });


### PR DESCRIPTION
I think the `sleep` and seconds increment are placed differently than intended inside  `if (FLAGS_print_tx_console)`. Probably just a small oversight.
