### PR TITLE
Fix reverse iterator skipping predecessor

### DIFF
--- a/backend/leanstore/storage/btree/core/BTreeGenericIterator.hpp
+++ b/backend/leanstore/storage/btree/core/BTreeGenericIterator.hpp
@@ -332,7 +332,7 @@ class BTreePessimisticIterator : public BTreePessimisticIteratorInterface
             if (is_equal) {
                return OP_RESULT::OK;
             } else if (cur > 0) {
-               cur -= 1;
+               cur -= 1; return OP_RESULT::OK;
             } else {
                continue;
             }


### PR DESCRIPTION
## Summary

- Fix BTreePessimisticIterator::prev() skipping the immediate predecessor after crossing a leaf-page boundary through the lower-fence fallback.
- Return immediately after lowerBound(fence) is decremented to the predecessor slot.

## Root cause

When the reverse iterator cannot use the optimistic sibling jump, prev() navigates to the previous leaf using the current leaf lower fence. For a non-equal fence, lowerBound() returns the insertion position and cur is decremented once to select the correct predecessor. The fallback branch did not return afterward, so the surrounding while loop ran again and decremented cur a second time at the top of the loop. The result was the key immediately before the actual predecessor.

One reproduced case was:

    query:    16497266874788550001
    expected: 16497158961977953382
    returned: 16497144325911138606

The expected and returned values were adjacent in sorted order. Iterator diagnostics showed lowerBound(fence) == 98, so the first decrement selected slot 97 (the expected predecessor), while the next loop iteration incorrectly selected slot 96.

## Validation

- Rebuilt LeanStore and the predecessor benchmark.
- Inserted 1,048,576 distinct uint64 keys in random order.
- Compared all 100,000 predecessor queries against RocksDB; all results matched.
- Reopened the persisted LeanStore database and completed all 100,000 queries in query-only mode.
